### PR TITLE
move to api v52. 

### DIFF
--- a/common/ZKLoginController.m
+++ b/common/ZKLoginController.m
@@ -23,7 +23,7 @@
 #import "credential.h"
 
 
-int DEFAULT_API_VERSION = 51;
+int DEFAULT_API_VERSION = 52;
 
 
 @interface ZKLoginController ()


### PR DESCRIPTION
there are no wsdl changes that impact the client code, so no zksforce changes