### PR TITLE
cache field completions during parsing.

### DIFF
--- a/AppExplorer/AppExplorer.xcodeproj/project.pbxproj
+++ b/AppExplorer/AppExplorer.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		F45C7EDD0B5FDA5200F93DD7 /* SchemaProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = F45C7EDB0B5FDA5200F93DD7 /* SchemaProtocol.m */; };
 		F45C7EEB0B5FDB5F00F93DD7 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F45C7EEA0B5FDB5F00F93DD7 /* WebKit.framework */; };
 		F45DDFDD0AABBA6100ED0BA0 /* Explorer.m in Sources */ = {isa = PBXBuildFile; fileRef = F45DDFDB0AABBA6100ED0BA0 /* Explorer.m */; };
+		F46070AF285BD78700EB7F5C /* Completions.m in Sources */ = {isa = PBXBuildFile; fileRef = F46070AE285BD78700EB7F5C /* Completions.m */; };
+		F46070B0285BD78700EB7F5C /* Completions.m in Sources */ = {isa = PBXBuildFile; fileRef = F46070AE285BD78700EB7F5C /* Completions.m */; };
 		F46D91070B33DFC800913AD2 /* StandAloneTableHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = F46D91010B33DFC800913AD2 /* StandAloneTableHeaderView.m */; };
 		F4805DE326FD4D9F005B1C24 /* OAuthMenuManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F4805DE226FD4D9F005B1C24 /* OAuthMenuManager.m */; };
 		F4805E0427063B1B005B1C24 /* LoginRowViewItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F4805E0227063B1B005B1C24 /* LoginRowViewItem.m */; };
@@ -300,6 +302,8 @@
 		F45C7EEA0B5FDB5F00F93DD7 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
 		F45DDFDB0AABBA6100ED0BA0 /* Explorer.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = Explorer.m; sourceTree = "<group>"; };
 		F45DDFDC0AABBA6100ED0BA0 /* Explorer.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = Explorer.h; sourceTree = "<group>"; };
+		F46070AD285BD78700EB7F5C /* Completions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Completions.h; sourceTree = "<group>"; };
+		F46070AE285BD78700EB7F5C /* Completions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Completions.m; sourceTree = "<group>"; };
 		F46D91000B33DFC800913AD2 /* StandAloneTableHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = StandAloneTableHeaderView.h; path = ../common/StandAloneTableHeaderView.h; sourceTree = SOURCE_ROOT; };
 		F46D91010B33DFC800913AD2 /* StandAloneTableHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; name = StandAloneTableHeaderView.m; path = ../common/StandAloneTableHeaderView.m; sourceTree = SOURCE_ROOT; };
 		F4805DE126FD4D9F005B1C24 /* OAuthMenuManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAuthMenuManager.h; sourceTree = "<group>"; };
@@ -813,6 +817,8 @@
 				F424A836262BCF1B00AD4F42 /* ColorizerStyle.m */,
 				F4BD5DDB264760A000ACBBAB /* DescribeExtras.h */,
 				F4BD5DDC264760A000ACBBAB /* DescribeExtras.m */,
+				F46070AD285BD78700EB7F5C /* Completions.h */,
+				F46070AE285BD78700EB7F5C /* Completions.m */,
 			);
 			name = SoqlSyntax;
 			sourceTree = "<group>";
@@ -1127,6 +1133,7 @@
 				F4805E0D27066606005B1C24 /* LoginTargetController.m in Sources */,
 				F4A2B962271F334700C20A42 /* CredentialsController.m in Sources */,
 				F412575D0B098593001622AC /* WeightedSObject.m in Sources */,
+				F46070AF285BD78700EB7F5C /* Completions.m in Sources */,
 				F4CD511B0B0C342100345D9E /* PlusMinusWidget.m in Sources */,
 				F4CD51200B0C350300345D9E /* FieldImportance.m in Sources */,
 				F46D91070B33DFC800913AD2 /* StandAloneTableHeaderView.m in Sources */,
@@ -1193,6 +1200,7 @@
 				F4DF0B5F2638BDA100B3A1A9 /* SoqlFunction.m in Sources */,
 				F4408FF02562F4C1005E8BB7 /* QueryColumns.m in Sources */,
 				F4BD5DD926470C8800ACBBAB /* Prefs.m in Sources */,
+				F46070B0285BD78700EB7F5C /* Completions.m in Sources */,
 				F48804DD2592BE57001D56F6 /* CaseInsensitiveKeyTest.m in Sources */,
 				F4DF0B632638BDB300B3A1A9 /* SoqlParser.m in Sources */,
 				F4A2B908271A41AD00C20A42 /* SearchQueryResult.m in Sources */,

--- a/AppExplorer/Completions.h
+++ b/AppExplorer/Completions.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Simon Fell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class Completion;
+
+@interface CompletionLocations : NSObject
+
+-(void)clear;
+-(void)add:(NSArray<Completion*>*)completions at:(NSRange)loc;
+-(NSArray<Completion*>*)completionsInRange:(NSRange)loc;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppExplorer/Completions.m
+++ b/AppExplorer/Completions.m
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 Simon Fell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#import "Completions.h"
+
+@interface CompletionLocations()
+@property NSMutableArray<NSArray<Completion*>*>* items;
+@end
+
+@implementation CompletionLocations
+
+// These have been stored directly in the AttributedString in the past with a custom key
+// but storing lots (100's) of those gets progressively slower and slower. So we stash
+// then in here instead, in an manner that just has to deal with our specific use case.
+
+-(id)init {
+    self = [super init];
+    self.items = [NSMutableArray arrayWithCapacity:256];
+    return self;
+}
+
+-(void)clear {
+    [self.items removeAllObjects];
+}
+
+-(void)add:(NSArray<Completion*>*)completions at:(NSRange)loc {
+    // we simply stash the completions away at every point in the range
+    // in the self.items array. The size of self.items will be ~ the length
+    // of the parsed SOQL.
+    NSUInteger end = NSMaxRange(loc);
+    if (self.items.count < end) {
+        NSArray *empty = [NSArray array];
+        while (self.items.count < end) {
+            [self.items addObject:empty];
+        }
+    }
+    for (NSUInteger p = loc.location; p < end; ++p) {
+        self.items[p] = completions;
+    }
+}
+
+-(NSArray<Completion*>*)completionsInRange:(NSRange)loc {
+    // look for the first non empty array starting at the end and going backwards.
+    if (self.items.count == 0) {
+        return [NSArray array];
+    }
+    for (NSUInteger p = MIN(self.items.count, NSMaxRange(loc))-1; p >= loc.location; --p) {
+        NSArray *r = self.items[p];
+        if (r.count > 0) {
+            return r;
+        }
+    }
+    return [NSArray array];
+}
+
+@end


### PR DESCRIPTION
They're cached for an unfiltered field list by sobject. For a query with lots of fields this helps a lot.

We also store the completions for a location in a new custom type instead of in the attributedString, this also helps a lot.